### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=HardWire
-version=1.0.2a
+version=1.0.2-a
 author=Enrico Sanino
 sentence =A spinoff of the Wire. This library allows you to communicate with I2C and Two Wire Interface devices, and control each step of any I2C transaction.
 paragraph=It allows the communication with I2C devices like temperature sensors, realtime clocks and many others using SDA (Data Line) and SCL (Clock Line).


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: 1.0.2a
```

This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/