### PR TITLE
Add maintainer field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,7 @@
 name=HardWire
 version=1.0.2-a
 author=Enrico Sanino
+maintainer=Enrico Sanino
 sentence =A spinoff of the Wire. This library allows you to communicate with I2C and Two Wire Interface devices, and control each step of any I2C transaction.
 paragraph=It allows the communication with I2C devices like temperature sensors, realtime clocks and many others using SDA (Data Line) and SCL (Clock Line).
 category=Communication


### PR DESCRIPTION
When the maintainer field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format