### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HARD_WIRE_MODE KEYWORD1
-NORMAL_MODE KEYWORD1
+HARD_WIRE_MODE	KEYWORD1
+NORMAL_MODE	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -20,11 +20,11 @@ endTransmission	KEYWORD2
 requestFrom	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
-onReceiveAdx KEYWORD2
-onReceiveData KEYWORD2
-onReceiveDataNack KEYWORD2
-onRequestData KEYWORD2
-onRequestDataNack KEYWORD2
+onReceiveAdx	KEYWORD2
+onReceiveData	KEYWORD2
+onReceiveDataNack	KEYWORD2
+onRequestData	KEYWORD2
+onRequestDataNack	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords